### PR TITLE
Changes to be made in the .sh scripts for MAC OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Requirements
 
 Running the SEMAFOR tool *requires* Java 1.6 or later. It should run on any platform (Windows, Unix, or Mac OS).
 
+For Mac:
+Install "brew install coreutils"
 
 Contents
 ========
@@ -173,6 +175,7 @@ Assuming that the user is at the root of the directory where SEMAFOR was decompr
 $  cd release/
 $  ./cleanAndCompile.sh
 
+For OSX: Before compiling change, we need to update the "readlink" in all the scripts in the "release/" folder with "greadlink". You can also "alias" the "readlink" with "greadlink".
 
 Running the Frame-Semantic Parser
 =================================


### PR DESCRIPTION
install "brew install coreutils" in your mac system and replace "readlink" with "greadlink" in all the script files in /release folder. (Only for mac)